### PR TITLE
Fix placeholder test to reflect home page text

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders home page hero text', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heroText = screen.getByText(/your intelligent emotional well-being companion/i);
+  expect(heroText).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update the default CRA test in `App.test.tsx` to look for the real hero text

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684765aec454832699b82717a7aaf6df