### PR TITLE
Update registration status code

### DIFF
--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -20,7 +20,8 @@ export const register = async (req: Request, res: Response, next: NextFunction) 
       role
     });
 
-    sendTokenResponse(user, 200, res);
+    // Return 201 status code to indicate successful creation
+    sendTokenResponse(user, 201, res);
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
## Summary
- return HTTP 201 when creating a new user

## Testing
- `npm test` *(fails: MongoMemoryServer missing libcrypto.so.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_684765aad3188326a5943e3d132fe1e9