### PR TITLE
Make husky install optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Sentivox is an AI-powered companion designed to combat senior loneliness through
    git clone https://github.com/yourusername/sentivox.git
    cd sentivox
    ```
-   **Note:** `npm install` in the backend runs `husky install`, which expects
-   the project to be inside a Git repository. Cloning via `git clone` ensures
-   the `.git` directory is present. If you downloaded the project as a ZIP,
-   run `git init` in the root before installing dependencies.
+  **Note:** `npm install` in the backend only installs Husky if a `.git`
+  directory exists and the `HUSKY` environment variable is not set to `0`.
+  If you plan to use Git hooks, make sure the project is inside a Git
+  repository (run `git init` if needed).
 
 2. Set up the backend:
    ```bash

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
     "seed": "ts-node -r tsconfig-paths/register src/utils/seed.ts",
     "docker:build": "docker build -t sentivox-backend .",
     "docker:run": "docker run -p 5000:5000 sentivox-backend",
-    "prepare": "husky install"
+    "prepare": "node -e \"if(process.env.HUSKY!=='0' && require('fs').existsSync('.git')){require('child_process').execSync('husky install',{stdio:'inherit'})}\""
   },
   "dependencies": {
     "@types/bcryptjs": "^2.4.6",


### PR DESCRIPTION
## Summary
- install Husky only when `.git` exists and `HUSKY` isn't `0`
- document the new Husky installation behaviour

## Testing
- `npm install` *(fails: Instance failed to start because a library is missing or cannot be opened: "libcrypto.so.1.1")*
- `npm test` *(fails: Instance failed to start because a library is missing or cannot be opened: "libcrypto.so.1.1")*

------
https://chatgpt.com/codex/tasks/task_e_684765a952f083269da42eefb3c3a854