### PR TITLE
Fix project name to Senntivox

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Sentivox
+Copyright (c) 2025 Senntivox
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
       <div style="width: 100%; display: flex; justify-content: center; padding: 20px 0 30px 0;">
         <img 
           src=".github/images/logo.png" 
-          alt="Sentivox Logo" 
+          alt="Senntivox Logo"
           style="width: 500px; max-width: 100%; height: auto; display: block;"
         />
       </div>
@@ -15,7 +15,7 @@
           color: #2c3e50;
           font-weight: 700;
           text-shadow: 1px 1px 2px rgba(0,0,0,0.1);
-        ">Sentivox</h1>
+        ">Senntivox</h1>
         <p style="
           font-size: 1.1rem; 
           margin: 0 0 0.5rem 0;
@@ -40,7 +40,7 @@
 </div>
 
 
-Sentivox is an AI-powered companion designed to combat senior loneliness through engaging conversations, memory stimulation, and daily support.
+Senntivox is an AI-powered companion designed to combat senior loneliness through engaging conversations, memory stimulation, and daily support.
 
 ## Features
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
-# Sentivox Backend
+# Senntivox Backend
 
-Backend API for the Sentivox application, built with Node.js, Express, TypeScript, and MongoDB. This application provides the necessary APIs for user authentication, profile management, and other core functionalities of the Sentivox platform.
+Backend API for the Senntivox application, built with Node.js, Express, TypeScript, and MongoDB. This application provides the necessary APIs for user authentication, profile management, and other core functionalities of the Senntivox platform.
 
 ## 🚀 Features
 
@@ -71,7 +71,7 @@ EMAIL_HOST=smtp.example.com
 EMAIL_PORT=587
 EMAIL_USER=your_email@example.com
 EMAIL_PASS=your_email_password
-EMAIL_FROM='Sentivox <noreply@sentivox.com>'
+EMAIL_FROM='Senntivox <noreply@senntivox.com>'
 
 # Frontend URLs
 FRONTEND_BASE_URL=http://localhost:3000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
-# Sentivox Frontend
+# Senntivox Frontend
 
-This directory contains the React client for the Sentivox project.
+This directory contains the React client for the Senntivox project.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- correct name in LICENSE
- standardize Senntivox spelling across README files

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847757f6908832683d447cfac6f56f2