### PR TITLE
Add email templates and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,16 @@ Sentivox is an AI-powered companion designed to combat senior loneliness through
 
    For the frontend:
    ```bash
-   cd frontend && npm install
+cd frontend && npm install
    npm test
    ```
+
+## Customizing Email Templates
+
+Email notifications in the backend are rendered using [Pug](https://pugjs.org/).
+Template files live in `backend/src/views/emails`. You can modify the provided
+templates or add new ones to match your branding. After editing a template,
+restart the backend server so the changes are picked up.
 
 ## License
 

--- a/backend/src/test/sendEmailTemplate.test.ts
+++ b/backend/src/test/sendEmailTemplate.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+// use the real implementation of sendEmail
+const { default: realSendEmail } = jest.requireActual('../utils/sendEmail');
+
+// Mock nodemailer to avoid actually sending emails
+import nodemailer from 'nodemailer';
+
+const sendMailMock = jest.fn().mockResolvedValue(undefined);
+(jest.spyOn(nodemailer, 'createTransport') as any).mockReturnValue({ sendMail: sendMailMock });
+
+describe('sendEmail utility', () => {
+  it('loads pug template without throwing', async () => {
+    await expect(
+      realSendEmail({
+        email: 'test@example.com',
+        subject: 'Test',
+        template: 'resetPassword',
+        data: { name: 'Tester', resetLink: 'http://example.com/reset' },
+      })
+    ).resolves.not.toThrow();
+    expect(sendMailMock).toHaveBeenCalled();
+  });
+});

--- a/backend/src/views/emails/resetPassword.pug
+++ b/backend/src/views/emails/resetPassword.pug
@@ -1,0 +1,9 @@
+doctype html
+html
+  head
+    title Reset Password
+  body
+    h1 Reset Your Password
+    p Hello #{name},
+    p Click the link below to reset your password.
+    a(href=resetLink) Reset Password


### PR DESCRIPTION
## Summary
- add Pug template directory with example template
- update README with info on customizing email templates
- add test to ensure sendEmail can load a template

## Testing
- `npm install` *(fails: libcrypto.so.1.1 missing for mongodb-memory-server)*
- `npm test` *(fails: libcrypto.so.1.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847757053248326b2571b498ab2a3f1