### PR TITLE
Add JWT method to User model

### DIFF
--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -1,6 +1,7 @@
 import mongoose, { Document, Schema } from 'mongoose';
 import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
 
 export interface IUser extends Document {
   name: string;
@@ -12,6 +13,7 @@ export interface IUser extends Document {
   resetPasswordExpire?: Date;
   createdAt: Date;
   matchPassword(enteredPassword: string): Promise<boolean>;
+  getSignedJwtToken(): string;
 }
 
 const UserSchema: Schema = new Schema({
@@ -69,6 +71,15 @@ UserSchema.pre<IUser>('save', async function(next) {
 // Match user entered password to hashed password in database
 UserSchema.methods.matchPassword = async function(enteredPassword: string) {
   return await bcrypt.compare(enteredPassword, this.password);
+};
+
+// Sign JWT and return
+UserSchema.methods.getSignedJwtToken = function() {
+  return jwt.sign(
+    { id: this._id },
+    process.env.JWT_SECRET as string,
+    { expiresIn: process.env.JWT_EXPIRE }
+  );
 };
 
 // Generate and hash password token

--- a/backend/src/test/userModel.test.ts
+++ b/backend/src/test/userModel.test.ts
@@ -1,5 +1,6 @@
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
 import User, { IUser } from '../models/User';
 
 describe('User Model', () => {
@@ -102,5 +103,24 @@ describe('User Model', () => {
     // Test wrong password
     const isWrongMatch = await user.matchPassword('wrongpassword');
     expect(isWrongMatch).toBe(false);
+  });
+
+  it('should generate a signed JWT token', async () => {
+    const user = new User({
+      name: 'JWT User',
+      email: 'jwt@example.com',
+      password: 'jwtpassword',
+      role: 'user' as const
+    });
+
+    await user.save();
+
+    const token = user.getSignedJwtToken();
+    expect(typeof token).toBe('string');
+
+    const decoded = jwt.verify(token, process.env.JWT_SECRET as string) as {
+      id: string;
+    };
+    expect(decoded.id).toBe(user._id.toString());
   });
 });


### PR DESCRIPTION
## Summary
- extend `IUser` interface with `getSignedJwtToken`
- implement `getSignedJwtToken` on the user schema
- test JWT generation in user model

## Testing
- `npm test` *(fails: MongoMemoryServer couldn't start because libcrypto.so.1.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684775631fc48326aced5b0f4ef37647