### PR TITLE
Update backend tests to check libssl1.1

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -121,6 +121,20 @@ docker-compose down
 
 ## 🧪 Testing
 
+Integration tests use `mongodb-memory-server`, which requires the legacy
+OpenSSL 1.1 libraries (`libssl.so.1.1` and `libcrypto.so.1.1`). Recent
+distributions may not ship these libraries by default.
+
+Install them manually before running the tests:
+
+```bash
+sudo apt-get update
+sudo apt-get install libssl1.1
+```
+
+Alternatively you can run the test command with `INSTALL_LIBSSL=1` and the
+script will attempt to install the package for you.
+
 ```bash
 # Run all tests
 npm test

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "build": "npm run clean && tsc",
     "clean": "rimraf dist",
     "serve": "node dist/server.js",
-    "test": "jest --passWithNoTests",
+    "test": "node ./scripts/check-libssl.js && jest --passWithNoTests",
     "test:watch": "jest --watch",
     "test:unit": "jest --config=jest.config.js --testPathPattern=src/.*\\.test\\.ts$",
     "test:integration": "jest --config=jest.config.js --testPathPattern=src/test/.*\\.test\\.ts$",

--- a/backend/scripts/check-libssl.js
+++ b/backend/scripts/check-libssl.js
@@ -1,0 +1,32 @@
+const { execSync } = require('child_process');
+
+function hasLibrary(lib) {
+  try {
+    const output = execSync('ldconfig -p', { encoding: 'utf8' });
+    return output.includes(lib);
+  } catch (e) {
+    return false;
+  }
+}
+
+function install() {
+  try {
+    execSync('apt-get update && apt-get install -y libssl1.1', { stdio: 'inherit' });
+  } catch (err) {
+    console.error('Automatic installation failed:', err.message);
+  }
+}
+
+if (!hasLibrary('libssl.so.1.1') || !hasLibrary('libcrypto.so.1.1')) {
+  if (process.env.INSTALL_LIBSSL === '1') {
+    console.log('Attempting to install libssl1.1...');
+    install();
+    if (!hasLibrary('libssl.so.1.1') || !hasLibrary('libcrypto.so.1.1')) {
+      console.error('libssl1.1 installation unsuccessful.');
+      process.exit(1);
+    }
+  } else {
+    console.error('Missing libssl.so.1.1 or libcrypto.so.1.1. Install libssl1.1 (e.g., `sudo apt-get install libssl1.1`) or run tests with INSTALL_LIBSSL=1 to attempt auto installation.');
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add a script that checks for `libssl.so.1.1`/`libcrypto.so.1.1`
- run this script before `jest`
- document installing `libssl1.1` for tests

## Testing
- `INSTALL_LIBSSL=1 npm test` *(fails: Unable to locate package libssl1.1)*

------
https://chatgpt.com/codex/tasks/task_e_684781b154348326a5f6f94b039f3f52