### PR TITLE
Fix backend libssl install fallback

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -129,11 +129,13 @@ Install them manually before running the tests:
 
 ```bash
 sudo apt-get update
-sudo apt-get install libssl1.1
+sudo apt-get install libssl1.1  # may require adding legacy packages
 ```
 
 Alternatively you can run the test command with `INSTALL_LIBSSL=1` and the
-script will attempt to install the package for you.
+script will attempt to install the package for you. If `apt-get` fails,
+the script downloads a legacy package from Ubuntu archives and installs it
+via `dpkg`.
 
 ```bash
 # Run all tests

--- a/backend/scripts/check-libssl.js
+++ b/backend/scripts/check-libssl.js
@@ -11,9 +11,18 @@ function hasLibrary(lib) {
 
 function install() {
   try {
-    execSync('apt-get update && apt-get install -y libssl1.1', { stdio: 'inherit' });
+    execSync('apt-get update', { stdio: 'inherit' });
+    execSync('apt-get install -y libssl1.1', { stdio: 'inherit' });
   } catch (err) {
-    console.error('Automatic installation failed:', err.message);
+    console.warn('libssl1.1 not available via apt, attempting manual download...');
+    try {
+      const url =
+        'http://mirrors.kernel.org/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb';
+      execSync(`curl -fsSL -o /tmp/libssl1.1.deb ${url}`, { stdio: 'inherit' });
+      execSync('dpkg -i /tmp/libssl1.1.deb', { stdio: 'inherit' });
+    } catch (e) {
+      console.error('Manual installation failed:', e.message);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- enhance backend's `check-libssl` script to auto-download libssl1.1
- clarify README on fallback installation

## Testing
- `npm install` (backend)
- `npm test` *(fails: multiple mongoose connection errors but libssl installed)*

------
https://chatgpt.com/codex/tasks/task_e_684783c79eb48326be866e5ba8905a8b