### PR TITLE
Fix test db setup

### DIFF
--- a/backend/src/test/auth.integration.test.ts
+++ b/backend/src/test/auth.integration.test.ts
@@ -1,8 +1,7 @@
 import request from 'supertest';
-import mongoose from 'mongoose';
-import app from '../server';
+import { describe, beforeEach, it, expect } from '@jest/globals';
+import app from '../app';
 import User from '../models/User';
-import { connectDB } from '../config/db';
 
 // Test user data
 const testUser = {
@@ -11,27 +10,10 @@ const testUser = {
   password: 'password123',
 };
 
-// Use a different port for testing to avoid conflicts
-const TEST_PORT = 5001;
-process.env.PORT = TEST_PORT.toString();
-
 describe('Auth API Integration Tests', () => {
-  const baseUrl = `http://localhost:${TEST_PORT}/api/v1`;
+  const baseUrl = '/api/v1';
 
-  beforeAll(async () => {
-    // Connect to the test database
-    await connectDB();
-  });
 
-  afterAll(async () => {
-    // Close the database connection
-    await mongoose.connection.close();
-  });
-
-  afterEach(async () => {
-    // Clean up the database after each test
-    await User.deleteMany({});
-  });
 
   describe('POST /auth/register', () => {
     it('should register a new user', async () => {

--- a/backend/src/test/auth.test.ts
+++ b/backend/src/test/auth.test.ts
@@ -1,8 +1,6 @@
 import request from 'supertest';
-import { MongoMemoryServer } from 'mongodb-memory-server';
-import mongoose from 'mongoose';
-import { describe, beforeAll, afterAll, afterEach, it, expect } from '@jest/globals';
-import { app } from '../server';
+import { describe, beforeEach, it, expect } from '@jest/globals';
+import app from '../app';
 
 // Extend the default timeout for tests
 jest.setTimeout(60000);
@@ -13,38 +11,10 @@ const testUser = {
   password: 'password123',
 };
 
-// Use a different port for testing to avoid conflicts
-const TEST_PORT = 5001;
-process.env.PORT = TEST_PORT.toString();
-
 describe('Auth API Integration Tests', () => {
-  const baseUrl = `http://localhost:${TEST_PORT}/api/v1`;
+  const baseUrl = '/api/v1';
 
-  let mongoServer: MongoMemoryServer;
 
-  beforeAll(async () => {
-    // Create a new MongoDB Memory Server instance
-    mongoServer = await MongoMemoryServer.create();
-    const mongoUri = mongoServer.getUri();
-    
-    // Connect to the in-memory database
-    await mongoose.connect(mongoUri);
-  });
-
-  afterEach(async () => {
-    // Clear all test data after each test
-    const collections = mongoose.connection.collections;
-    for (const key in collections) {
-      const collection = collections[key];
-      await collection.deleteMany({});
-    }
-  });
-
-  afterAll(async () => {
-    // Close the mongoose connection and stop the MongoDB Memory Server
-    await mongoose.disconnect();
-    await mongoServer.stop();
-  });
 
   describe('POST /auth/register', () => {
     it('should register a new user', async () => {

--- a/backend/src/test/authController.test.ts
+++ b/backend/src/test/authController.test.ts
@@ -1,36 +1,15 @@
 import request from 'supertest';
-import mongoose from 'mongoose';
-import { MongoMemoryServer } from 'mongodb-memory-server';
-import { app } from '../server';
+import { describe, beforeEach, it, expect } from '@jest/globals';
+import app from '../app';
 import User from '../models/User';
 
 describe('Auth Controller', () => {
-  let mongoServer: MongoMemoryServer;
   let testUser = {
     name: 'Test User',
     email: 'test@example.com',
     password: 'testpassword123'
   };
 
-  beforeAll(async () => {
-    // Start MongoDB Memory Server
-    mongoServer = await MongoMemoryServer.create();
-    const mongoUri = mongoServer.getUri();
-    
-    // Connect to the in-memory database
-    await mongoose.connect(mongoUri);
-  });
-
-  afterEach(async () => {
-    // Clear all test data after each test
-    await User.deleteMany({});
-  });
-
-  afterAll(async () => {
-    // Close the mongoose connection and stop the MongoDB Memory Server
-    await mongoose.disconnect();
-    await mongoServer.stop();
-  });
 
   describe('POST /api/v1/auth/register', () => {
     it('should register a new user', async () => {

--- a/backend/src/test/setupAfterEnv.ts
+++ b/backend/src/test/setupAfterEnv.ts
@@ -1,15 +1,9 @@
-import { setupTestDB, clearTestDB, closeTestDB } from './__utils__/testUtils';
-
-// This will hold our in-memory MongoDB instance
-let mongoServer: any;
+import { clearTestDB } from './__utils__/testUtils';
 
 // Set up the test environment before all tests
 beforeAll(async () => {
   // Set test environment
   process.env.NODE_ENV = 'test';
-  
-  // Setup in-memory MongoDB server
-  mongoServer = await setupTestDB();
   
   // Mock console methods to reduce test noise
   jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -31,7 +25,6 @@ afterEach(async () => {
 
 // Clean up after all tests are done
 afterAll(async () => {
-  await closeTestDB(mongoServer);
   jest.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Summary
- clean up per-test database setup to avoid multiple connections
- use the Express app directly in integration tests

## Testing
- `INSTALL_LIBSSL=1 npm test --silent` *(fails: Auth Controller tests)*

------
https://chatgpt.com/codex/tasks/task_e_684790b58b9c83268413e8639d1c6a26