### PR TITLE
Ensure MongoDB connection before clearing test DB

### DIFF
--- a/backend/src/test/setupAfterEnv.ts
+++ b/backend/src/test/setupAfterEnv.ts
@@ -1,4 +1,17 @@
+import mongoose from 'mongoose';
 import { clearTestDB } from './__utils__/testUtils';
+
+/**
+ * Ensures that the mongoose connection is fully open before
+ * attempting to clear the test database. This prevents errors
+ * when tests start before the connection is ready.
+ */
+async function waitForConnection(): Promise<void> {
+  if (mongoose.connection.readyState === 1) return;
+  await new Promise<void>((resolve) => {
+    mongoose.connection.once('open', () => resolve());
+  });
+}
 
 // Set up the test environment before all tests
 beforeAll(async () => {
@@ -19,6 +32,7 @@ beforeAll(async () => {
 
 // Clean up database between tests
 afterEach(async () => {
+  await waitForConnection();
   await clearTestDB();
   jest.clearAllMocks();
 });


### PR DESCRIPTION
## Summary
- wait for open Mongoose connection in `setupAfterEnv.ts`
- clear test database only after connection is ready

## Testing
- `npx jest --version`
- `MONGOMS_DOWNLOAD_DIR=/tmp npx jest src/test/basic.test.ts --runInBand --silent` *(fails: Error during cleanup)*

------
https://chatgpt.com/codex/tasks/task_e_68479dc7dcc08326a9046a4fa9797fed